### PR TITLE
不要なgem 'therubyracer'を削除し、Gemfile.lockを更新

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,8 +50,6 @@ gem 'mutex_m'
 # install ffi
 gem 'ffi'
 
-gem 'therubyracer', platforms: :ruby
-
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   # gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     erb (5.0.1)
     erubi (1.13.0)
     execjs (2.9.1)
+    ffi (1.17.0-aarch64-linux-gnu)
     ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -100,7 +101,6 @@ GEM
       reline (>= 0.4.2)
     json (2.12.2)
     language_server-protocol (3.17.0.5)
-    libv8 (3.16.14.19.1-x86_64-linux)
     logger (1.7.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -125,6 +125,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.3)
+    nokogiri (1.16.7-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     parallel (1.27.0)
@@ -185,7 +187,6 @@ GEM
     rdoc (6.14.0)
       erb
       psych (>= 4.0.0)
-    ref (2.0.0)
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
@@ -246,9 +247,6 @@ GEM
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     stringio (3.1.7)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (1.3.2)
     tilt (2.4.0)
     timeout (0.4.3)
@@ -270,6 +268,7 @@ GEM
     zeitwerk (2.6.17)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -290,7 +289,6 @@ DEPENDENCIES
   rubocop-rspec
   sass-rails (>= 6)
   spring-commands-rspec
-  therubyracer
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)


### PR DESCRIPTION
## 概要 (Overview)

therubyracerを削除し、Arm Macで`docker compose build`が通るように修正しました。

## その他 (Additional Context)

流石にもうなくても大丈夫なのでは…？